### PR TITLE
Implement double column layout

### DIFF
--- a/src/components/PostPage.astro
+++ b/src/components/PostPage.astro
@@ -7,7 +7,7 @@ const { page } = Astro.props
 let delay = 0
 const interval = 50
 ---
-<div class="transition flex flex-col rounded-[var(--radius-large)] bg-[var(--card-bg)] py-1 md:py-0 md:bg-transparent md:gap-4 mb-4">
+<div class="transition grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
     {page.data.map((entry: { data: { draft: boolean; title: string; tags: string[]; category: string; published: Date; image: string; description: string; updated: Date; pinned: boolean; }; slug: string; }) => {
         return (
             <PostCard

--- a/src/components/PostPage.astro
+++ b/src/components/PostPage.astro
@@ -7,7 +7,7 @@ const { page } = Astro.props
 let delay = 0
 const interval = 50
 ---
-<div class="transition grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+<div class="transition grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4 rounded-[var(--radius-large)] bg-[var(--card-bg)] py-1 md:py-0 md:bg-transparent">
     {page.data.map((entry: { data: { draft: boolean; title: string; tags: string[]; category: string; published: Date; image: string; description: string; updated: Date; pinned: boolean; }; slug: string; }) => {
         return (
             <PostCard


### PR DESCRIPTION
## Summary
- switch post listing to 2-column grid on the homepage

## Testing
- `pnpm lint` *(fails: some biome errors)*

------
https://chatgpt.com/codex/tasks/task_e_68400607c81c83279330745f1e11032c